### PR TITLE
Add support for files as input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 */
+*.txt
+!requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project aims to provide an easy-to-use CLI tool for downloading whole websi
 
 This tool however only downloads the provided HTML file as well as related CSS/JS files. Hyperlinks are retained intact to link to webpages.
 
+---
 
 ## Requirements
 * Python 3
@@ -17,18 +18,35 @@ This tool however only downloads the provided HTML file as well as related CSS/J
 * requests (see [Installation](#Installation))
 * BeautifulSoup (see [Installation](#Installation))
 
+---
+
 ## Installation
 You can just install the dependencies using pip: `pip install -r requirements.txt`
 
 If you want to manually install the required packages using your preferrec package manager, see [requirements.txt](requirements.txt) for a list of packages
 
+---
+
 ## Usage
+For a list of available parameters, run `python download.py -h`.
+
+### single URL
 Run the Python script `download.py`. You can pass the URL to download as a parameter, otherwise you will be prompted to enter it.
 
 Example: `python download.py https://google.com`
 
+
+### multiple URLs
+Create a file (e.g. `urls.txt`) containing one (1) URL per line. Now run the Python script using the `-f` Parameter, specifying your filename.
+
+Example: `python download.py -f urls.txt`
+
+---
+
 ## Issues & Features
 If you find any problems or have a feature request, feel free to open an Issue or Pull Request.
+
+---
 
 ## License
 This project is licensed under **GNU General Public License v3.0**.

--- a/download.py
+++ b/download.py
@@ -15,21 +15,6 @@ import requests
 from bs4 import BeautifulSoup
 
 
-PARSER = argparse.ArgumentParser(
-    description='Download a website with html & css')
-PARSER.add_argument('url', metavar='URL', type=str,
-                    nargs='?', help='full url to website')
-
-URL = PARSER.parse_args().url
-
-if not URL:
-    URL = input("Please enter a url: ")
-
-    if not URL:
-        PARSER.print_help()
-        sys.exit(1)
-
-
 # define helper functions
 def get_valid_filename(name):
     '''
@@ -44,7 +29,7 @@ def get_valid_filename(name):
     return filename
 
 
-def save_file(path_l, sourceurl):
+def save_file(path_l: list, sourceurl: str, cur_dir: str):
     '''
         Download file from sourceurl and save to path.
 
@@ -53,38 +38,37 @@ def save_file(path_l, sourceurl):
     '''
     print(f"downloading file {path_l[-1]}...")
 
-    cur_p = FOLDER
     for subpath in path_l[:-1]:
         subpath = get_valid_filename(subpath)
-        cur_p = os.path.join(cur_p, subpath)
-        if not os.path.exists(cur_p):
-            os.mkdir(cur_p)
+        cur_dir = os.path.join(cur_dir, subpath)
+        if not os.path.exists(cur_dir):
+            os.mkdir(cur_dir)
 
     filename = get_valid_filename(path_l[-1])
 
-    with open(os.path.join(cur_p, filename), 'wb') as file:
+    with open(os.path.join(cur_dir, filename), 'wb') as file:
         script_f = requests.get(sourceurl).content
         file.write(script_f)
 
 
-def prep_url(sourceurl):
+def prep_url(sourceurl: str, site_url: str):
     '''
         Prepare url for download.
 
         @args sourceurl: url to be prepared
     '''
     if sourceurl.startswith('./'):
-        sourceurl = f"{'/'.join(URL.split('/')[:-1])}{sourceurl.replace('./','/')}"
+        sourceurl = f"{'/'.join(site_url.split('/')[:-1])}{sourceurl.replace('./','/')}"
 
     if sourceurl.startswith('/'):
-        sourceurl = f"{URL.split('/')[0]}//{URL.split('/')[2]}{sourceurl}"
+        sourceurl = f"{site_url.split('/')[0]}//{site_url.split('/')[2]}{sourceurl}"
 
     path_l = sourceurl.replace('..', 'dot').split('/')
 
     if sourceurl.startswith('http'):
         path_l = path_l[3:]
     if sourceurl.startswith('..'):
-        sourceurl = f"{'/'.join(URL.split('/')[:-1])}"
+        sourceurl = f"{'/'.join(site_url.split('/')[:-1])}"
 
         sourceurl = sourceurl.split('/')
         sourceurl = sourceurl[:-(path_l.count('dot'))]
@@ -93,70 +77,103 @@ def prep_url(sourceurl):
     return (sourceurl, path_l)
 
 
-# request url
+def download_page(site_url: str):
+    '''
+        Download page and save to file.
+    '''
+    # request url
+    REQ = requests.get(site_url)
+    SOUP = BeautifulSoup(REQ.content, 'html.parser')
 
-REQ = requests.get(URL)
-SOUP = BeautifulSoup(REQ.content, 'html.parser')
+    TITLE = None
+    if SOUP.head.title is not None:
+        TITLE = SOUP.head.title.contents[0]
+    elif SOUP.title is not None:
+        TITLE = SOUP.title.contents[0]
+    else:
+        TITLE = site_url.split('/')[2]
 
-TITLE = None
-if SOUP.head.title is not None:
-    TITLE = SOUP.head.title.contents[0]
-elif SOUP.title is not None:
-    TITLE = SOUP.title.contents[0]
-else:
-    TITLE = URL.split('/')[2]
+    CWD = os.getcwd()
+    FOLDER = os.path.join(CWD, get_valid_filename(TITLE))
 
-CWD = os.getcwd()
-FOLDER = os.path.join(CWD, get_valid_filename(TITLE))
+    if os.path.exists(FOLDER):
+        rmtree(FOLDER)
 
-if os.path.exists(FOLDER):
-    rmtree(FOLDER)
+    os.mkdir(FOLDER)
 
-os.mkdir(FOLDER)
+    # get links, dereference, download and save
+    for link in SOUP.find_all('link'):
+        if link.get('rel', [''])[0].lower() == 'stylesheet':
 
-# get links, dereference, download and save
-for link in SOUP.find_all('link'):
-    if link.get('rel', [''])[0].lower() == 'stylesheet':
+            source_url = link.get('href', '')
 
-        source_url = link.get('href', '')
+            (source, path) = prep_url(source_url, site_url)
+            link['href'] = '/'.join(path)
 
-        (source, path) = prep_url(source_url)
-        link['href'] = '/'.join(path)
+            save_file(path, source, FOLDER)
 
-        save_file(path, source)
+    for script in SOUP.find_all('script'):
+        if script.get('src', '') != '':
+            source_url = script.get('src')
 
-for script in SOUP.find_all('script'):
-    if script.get('src', '') != '':
-        source_url = script.get('src')
+            (source, path) = prep_url(source_url, site_url)
 
-        (source, path) = prep_url(source_url)
+            script['src'] = '/'.join(path)
 
-        script['src'] = '/'.join(path)
+            save_file(path, source, FOLDER)
 
-        save_file(path, source)
+    # fix relative links
+    for link in SOUP.find_all('a'):
+        href = link.get('href', '')
+        if href.startswith('./'):
+            link['href'] = f"{'/'.join(site_url.split('/')[:-1])}{href.replace('./','/')}"
 
-# fix relative links
-for link in SOUP.find_all('a'):
-    href = link.get('href', '')
-    if href.startswith('./'):
-        link['href'] = f"{'/'.join(URL.split('/')[:-1])}{href.replace('./','/')}"
+        elif href.startswith('/'):
+            link['href'] = f"{site_url.split('/')[0]}//{site_url.split('/')[2]}{href}"
 
-    elif href.startswith('/'):
-        link['href'] = f"{URL.split('/')[0]}//{URL.split('/')[2]}{href}"
+        elif href.startswith('..'):
+            href = href.split('/')
+            dot_cnt = href.count('..')
+            source_url = f"{'/'.join(site_url.split('/')[:-1])}"
 
-    elif href.startswith('..'):
-        href = href.split('/')
-        dot_cnt = href.count('..')
-        source_url = f"{'/'.join(URL.split('/')[:-1])}"
+            source_url = source_url.split('/')
+            source_url = source_url[:-(dot_cnt)]
+            source_url = f"{'/'.join(source_url)}/{'/'.join(href[dot_cnt:])}"
 
-        source_url = source_url.split('/')
-        source_url = source_url[:-(dot_cnt)]
-        source_url = f"{'/'.join(source_url)}/{'/'.join(href[dot_cnt:])}"
+            link['href'] = source_url
 
-        link['href'] = source_url
+    with open(os.path.join(FOLDER, 'index.html'), 'wb') as index_file:
+        index_file.write(SOUP.encode())
 
-with open(os.path.join(FOLDER, 'index.html'), 'wb') as index_file:
-    index_file.write(SOUP.encode())
+    print()
+    print(f"    Website '{TITLE}' saved to {FOLDER}")
 
-print()
-print(f"    Website '{TITLE}' saved to {FOLDER}")
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser(
+        description='Download a website with html & css')
+    PARSER.add_argument('url', metavar='URL', type=str,
+                        nargs='?', help='full url to website')
+    PARSER.add_argument('-f', '--file', metavar='FILE', type=str,
+                        nargs='?', dest='file', help='specify input file')
+
+    URL = PARSER.parse_args().url
+    FILE = PARSER.parse_args().file
+
+    if not URL:
+        if FILE:
+            print(f"Reading URLs from file {FILE}")
+            with open(FILE, 'r') as file:
+                for line in file.readlines():
+                    URL = line.strip()
+                    download_page(URL)
+            sys.exit(0)
+
+        else:
+            URL = input("Please enter a url: ")
+
+            if not URL:
+                PARSER.print_help()
+                sys.exit(1)
+
+    download_page(URL)

--- a/download.py
+++ b/download.py
@@ -82,27 +82,26 @@ def download_page(site_url: str):
         Download page and save to file.
     '''
     # request url
-    REQ = requests.get(site_url)
-    SOUP = BeautifulSoup(REQ.content, 'html.parser')
+    req = requests.get(site_url)
+    soup = BeautifulSoup(req.content, 'html.parser')
 
-    TITLE = None
-    if SOUP.head.title is not None:
-        TITLE = SOUP.head.title.contents[0]
-    elif SOUP.title is not None:
-        TITLE = SOUP.title.contents[0]
+    title = None
+    if soup.head.title is not None:
+        title = soup.head.title.contents[0]
+    elif soup.title is not None:
+        title = soup.title.contents[0]
     else:
-        TITLE = site_url.split('/')[2]
+        title = site_url.split('/')[2]
 
-    CWD = os.getcwd()
-    FOLDER = os.path.join(CWD, get_valid_filename(TITLE))
+    folder = os.path.join(os.getcwd(), get_valid_filename(title))
 
-    if os.path.exists(FOLDER):
-        rmtree(FOLDER)
+    if os.path.exists(folder):
+        rmtree(folder)
 
-    os.mkdir(FOLDER)
+    os.mkdir(folder)
 
     # get links, dereference, download and save
-    for link in SOUP.find_all('link'):
+    for link in soup.find_all('link'):
         if link.get('rel', [''])[0].lower() == 'stylesheet':
 
             source_url = link.get('href', '')
@@ -110,9 +109,9 @@ def download_page(site_url: str):
             (source, path) = prep_url(source_url, site_url)
             link['href'] = '/'.join(path)
 
-            save_file(path, source, FOLDER)
+            save_file(path, source, folder)
 
-    for script in SOUP.find_all('script'):
+    for script in soup.find_all('script'):
         if script.get('src', '') != '':
             source_url = script.get('src')
 
@@ -120,10 +119,10 @@ def download_page(site_url: str):
 
             script['src'] = '/'.join(path)
 
-            save_file(path, source, FOLDER)
+            save_file(path, source, folder)
 
     # fix relative links
-    for link in SOUP.find_all('a'):
+    for link in soup.find_all('a'):
         href = link.get('href', '')
         if href.startswith('./'):
             link['href'] = f"{'/'.join(site_url.split('/')[:-1])}{href.replace('./','/')}"
@@ -142,11 +141,11 @@ def download_page(site_url: str):
 
             link['href'] = source_url
 
-    with open(os.path.join(FOLDER, 'index.html'), 'wb') as index_file:
-        index_file.write(SOUP.encode())
+    with open(os.path.join(folder, 'index.html'), 'wb') as index_file:
+        index_file.write(soup.encode())
 
     print()
-    print(f"    Website '{TITLE}' saved to {FOLDER}")
+    print(f"    Website '{title}' saved to {folder}")
 
 
 if __name__ == '__main__':
@@ -163,8 +162,8 @@ if __name__ == '__main__':
     if not URL:
         if FILE:
             print(f"Reading URLs from file {FILE}")
-            with open(FILE, 'r') as file:
-                for line in file.readlines():
+            with open(FILE, 'r', encoding='utf-8') as input_file:
+                for line in input_file.readlines():
                     URL = line.strip()
                     download_page(URL)
             sys.exit(0)


### PR DESCRIPTION
Resolves #2 

Allows download of multiple URLs at once. URLs have to be specified as a file, seperated by newlines (one URL per line).

- Add CLI option `-f` to specify input file for URLs 